### PR TITLE
NOTICKET - Add optional walletReferenceId passthrough to V2 play and bonus win

### DIFF
--- a/src/create-rgs-service.ts
+++ b/src/create-rgs-service.ts
@@ -209,6 +209,7 @@ export const createRgsService = ({
     gameRoundUuid,
     coinType,
     payload,
+    walletReferenceId,
   }: {
     accessToken: string;
     tenantId?: number;
@@ -221,6 +222,7 @@ export const createRgsService = ({
     gameRoundUuid: string;
     coinType: CoinType;
     payload?: Record<string, string | number>;
+    walletReferenceId?: string;
   }): Promise<Play> => {
     const requestConfig: AxiosRequestConfig = {
       url: `${rgsAPIHost}/${rgsGameId}/v2/register-user-play`,
@@ -241,6 +243,7 @@ export const createRgsService = ({
         gameRoundUuid,
         coinType,
         payload,
+        walletReferenceId,
       },
     };
 
@@ -365,6 +368,7 @@ export const createRgsService = ({
     playWinTimestamp,
     gameRoundCurrentProgressInMs,
     payload,
+    walletReferenceId,
   }: {
     accessToken?: string;
     tenantId?: number;
@@ -378,6 +382,7 @@ export const createRgsService = ({
     playWinTimestamp: number;
     gameRoundCurrentProgressInMs: number;
     payload?: Record<string, string | number>;
+    walletReferenceId?: string;
   }): Promise<Play> => {
     const requestConfig: AxiosRequestConfig = {
       url: `${rgsAPIHost}/${rgsGameId}/v2/register-play-win`,
@@ -398,6 +403,7 @@ export const createRgsService = ({
         playWinTimestamp,
         gameRoundCurrentProgressInMs,
         payload,
+        walletReferenceId,
       },
     };
 
@@ -422,6 +428,7 @@ export const createRgsService = ({
     gameRoundUuid,
     coinType,
     payload,
+    walletReferenceId,
   }: {
     userId: number;
     userNickname: string;
@@ -429,6 +436,7 @@ export const createRgsService = ({
     gameRoundUuid: string;
     coinType: CoinType;
     payload?: Record<string, string | number>;
+    walletReferenceId?: string;
   }): Promise<Play> => {
     const requestConfig: AxiosRequestConfig = {
       url: `${rgsAPIHost}/${rgsGameId}/register-bonus-win`,
@@ -443,6 +451,7 @@ export const createRgsService = ({
         coinType,
         gameRoundUuid,
         payload,
+        walletReferenceId,
       },
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export interface RgsService {
     gameRoundUuid,
     coinType,
     payload,
+    walletReferenceId,
   }: {
     accessToken: string;
     tenantId?: number;
@@ -71,6 +72,7 @@ export interface RgsService {
     gameRoundUuid: string;
     coinType: CoinType;
     payload?: Record<string, string | number>;
+    walletReferenceId?: string;
   }) => Promise<Play>;
 
   registerBonusWin: ({
@@ -80,6 +82,7 @@ export interface RgsService {
     gameRoundUuid,
     coinType,
     payload,
+    walletReferenceId,
   }: {
     userId: number;
     userNickname: string;
@@ -87,6 +90,7 @@ export interface RgsService {
     gameRoundUuid: string;
     coinType: CoinType;
     payload?: Record<string, string | number>;
+    walletReferenceId?: string;
   }) => Promise<Play>;
   deregisterUserPlay: ({
     userId,
@@ -113,6 +117,7 @@ export interface RgsService {
     playWinTimestamp,
     gameRoundCurrentProgressInMs,
     payload,
+    walletReferenceId,
   }: {
     accessToken?: string;
     tenantId?: number;
@@ -126,6 +131,7 @@ export interface RgsService {
     playWinTimestamp: number;
     gameRoundCurrentProgressInMs: number;
     payload?: Record<string, string | number>;
+    walletReferenceId?: string;
   }) => Promise<Play>;
 
   registerPlayWin: ({


### PR DESCRIPTION
## Summary
- Add optional `walletReferenceId?: string` parameter to `registerUserPlayV2`, `registerPlayWinV2`, and `registerBonusWin` (and their payload types in `types.ts`).
- Forward `walletReferenceId` in the axios request body so games can pin a stable wallet-side reference id on the underlying transaction (e.g., to restore previous deterministic suffix patterns).
- No behavior change for existing callers — field is fully optional.

## Test plan
- [ ] Existing call sites that omit `walletReferenceId` continue to type-check and serialize unchanged.
- [ ] A consumer (el-wheel) is updated in parallel to pass `walletReferenceId` for the three calls and confirms it lands in the RGS request body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)